### PR TITLE
ci: enforce least-privilege permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run on Ubuntu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run on Ubuntu


### PR DESCRIPTION
## Enforce least-privilege permissions

This PR adds explicit `permissions` blocks to GitHub Actions workflow files that currently have no permissions defined, following the principle of least privilege.

### Changes
- `ci.yml`: contents: read, packages: write
- `lint.yml`: contents: read
- `test-e2e.yml`: contents: read
- `test.yml`: contents: read
- `release.yml`: permissions: {} (defense-in-depth)

### Why
Without explicit permissions, workflows inherit the default token permissions configured at the repository or organization level. By explicitly declaring the minimum required permissions, we reduce the blast radius if a workflow is compromised.

### References
- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- [Automatic token authentication permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
